### PR TITLE
AuctionMaxPrice to Zero when auction ends

### DIFF
--- a/src/main/java/bt/dapps/SignumArt2.java
+++ b/src/main/java/bt/dapps/SignumArt2.java
@@ -299,6 +299,7 @@ public class SignumArt2 extends Contract {
 					owner = highestBidder; // new owner
 					highestBidder = null;
 					status = STATUS_NOT_FOR_SALE;
+					auctionMaxPrice = ZERO;
 					sendMessage(owner.getId(), currentPrice, trackNewOwner);
 					
 					cancelOfferIfPresent();


### PR DESCRIPTION
We need to set the auctionMaxPrice to Zero when thr auction ends without bids to keep the data stack in sync.